### PR TITLE
Spectator mode

### DIFF
--- a/src/game/GameStateMatch.cpp
+++ b/src/game/GameStateMatch.cpp
@@ -180,12 +180,13 @@ void GameStateMatch::update(const float delta) {
     GameManager::instance()->updateMarines(delta);
     GameManager::instance()->updateZombies(delta);
 
-    // Move Camera
+    // Move Camera + handling to ensure spectator support
     if (player.marine != nullptr) {
         camera.move(player.marine->getX(), player.marine->getY());
+    } else {
+        player.moveGhost(delta);
+        camera.move(player.getGhost().getX(),player.getGhost().getY());
     }
-    
-
 
 }
 

--- a/src/game/GameStateMatch.cpp
+++ b/src/game/GameStateMatch.cpp
@@ -181,7 +181,10 @@ void GameStateMatch::update(const float delta) {
     GameManager::instance()->updateZombies(delta);
 
     // Move Camera
-    camera.move(player.marine->getX(), player.marine->getY());
+    if (player.marine != nullptr) {
+        camera.move(player.marine->getX(), player.marine->getY());
+    }
+    
 
 
 }

--- a/src/player/Ghost.cpp
+++ b/src/player/Ghost.cpp
@@ -1,0 +1,17 @@
+#include "Ghost.h"
+
+Ghost::Ghost() : Movable(GHOST_VELOCITY) {
+    printf("Create Ghost\n");
+}
+
+Ghost::~Ghost() {
+    printf("Destroy Ghost\n");
+}
+    
+void Ghost::onCollision() {
+    //do nothing
+}
+
+void Ghost::collidingProjectile(int damage) {
+    //do nothing.
+}

--- a/src/player/Ghost.h
+++ b/src/player/Ghost.h
@@ -1,0 +1,33 @@
+/*
+ * Created by Matt Goerwell, March 13 2017
+ */
+#ifndef GHOST_H
+#define GHOST_H
+#include <string>
+#include "../sprites/LTexture.h"
+#include "../basic/Entity.h"
+#include "../basic/Movable.h"
+#include "../collision/CollisionHandler.h"
+#include <math.h>
+#include <vector>
+#include <SDL2/SDL.h>
+#include "../view/Window.h"
+
+#define GHOST_VELOCITY 500
+
+/*
+ * This is a simple class that defines a movable entity to allow spectators to move around the map.
+ */
+class Ghost : public Movable {
+public:
+    //ctor
+    Ghost();
+    //dtor
+    virtual ~Ghost();
+    //required by parent
+    void onCollision();
+    //required by parent
+    void collidingProjectile(int damage);
+};
+
+#endif

--- a/src/player/Player.cpp
+++ b/src/player/Player.cpp
@@ -82,10 +82,11 @@ void Player::handleKeyboardInput(const Uint8 *state) {
     float x = 0;
     float y = 0;
     float velocity;
+    //Check to see if we are currently a marine or a spectator (ghost)
     if (marine != nullptr) {
         velocity = marine->getVelocity();
     } else {
-        velocity = 0;
+        velocity = GHOST_VELOCITY;
     }
     
 
@@ -125,17 +126,19 @@ void Player::handleKeyboardInput(const Uint8 *state) {
             marine->inventory.useItem();
         }
         if(state[SDL_SCANCODE_K]) {
+            ghost.setPosition(marine->getX(),marine->getY());
             GameManager::instance()->deleteMarine(0);
             marine = nullptr;
         }
 
     }
-
+    //Movement updates
     if (marine != nullptr) {
-            marine->setDY(y);
-            marine->setDX(x);
+        marine->setDY(y);
+        marine->setDX(x);
     } else {
-
+        ghost.setDX(x);
+        ghost.setDY(y);
     }
 
 }
@@ -164,4 +167,9 @@ void Player::handleTempTurret(SDL_Renderer *renderer) {
        GameManager::instance()->deleteTurret(tempTurretID);
        tempTurretID = -1;
    }
+}
+
+//This method updates the spectators position on the map, for the purpose of camera tracking.
+void Player::moveGhost(const float delta) {
+    ghost.move(ghost.getDX()*delta,ghost.getDY()*delta,GameManager::instance()->getCollisionHandler());   
 }

--- a/src/player/Player.cpp
+++ b/src/player/Player.cpp
@@ -26,8 +26,10 @@ void Player::handleMouseUpdate(Window& w, float camX, float camY) {
     mouseDeltaY = w.getHeight()/2 - mouseY;
 
     double angle = ((atan2(mouseDeltaX, mouseDeltaY)* radianConvert)/M_PI) * - 1;
-
-    marine->setAngle(angle);
+    if (marine != nullptr) {
+        marine->setAngle(angle);
+    }
+    
 
     if (tempBarricadeID > -1) {
         Barricade &tempBarricade = GameManager::instance()->getBarricade(tempBarricadeID);
@@ -79,7 +81,13 @@ void Player::handlePlacementClick(SDL_Renderer *renderer) {
 void Player::handleKeyboardInput(const Uint8 *state) {
     float x = 0;
     float y = 0;
-    float velocity = marine->getVelocity();
+    float velocity;
+    if (marine != nullptr) {
+        velocity = marine->getVelocity();
+    } else {
+        velocity = 0;
+    }
+    
 
     // Check for move inputs
     if (state[SDL_SCANCODE_UP] || state[SDL_SCANCODE_W]) {
@@ -95,27 +103,41 @@ void Player::handleKeyboardInput(const Uint8 *state) {
         x += velocity;
     }
 
-    //Inventory inputs
-    if (state[SDL_SCANCODE_1]){
-        marine->inventory.switchCurrent(0);
-    } else if (state[SDL_SCANCODE_2]){
-        marine->inventory.switchCurrent(1);
-    } else if (state[SDL_SCANCODE_3]){
-        marine->inventory.switchCurrent(2);
+    
+    if (marine != nullptr) {
+        //Inventory inputs
+        if (state[SDL_SCANCODE_1]){
+            marine->inventory.switchCurrent(0);
+        } else if (state[SDL_SCANCODE_2]){
+            marine->inventory.switchCurrent(1);
+        } else if (state[SDL_SCANCODE_3]){
+            marine->inventory.switchCurrent(2);
+        }
+
+        //Weapon input
+        if(state[SDL_SCANCODE_R]){
+            marine->inventory.getCurrent()->reloadClip();
+        }
+        if(state[SDL_SCANCODE_E]){
+            marine->checkForPickUp();
+        }
+        if(state[SDL_SCANCODE_I]) {
+            marine->inventory.useItem();
+        }
+        if(state[SDL_SCANCODE_K]) {
+            GameManager::instance()->deleteMarine(0);
+            marine = nullptr;
+        }
+
     }
 
-    //Weapon input
-    if(state[SDL_SCANCODE_R]){
-        marine->inventory.getCurrent()->reloadClip();
+    if (marine != nullptr) {
+            marine->setDY(y);
+            marine->setDX(x);
+    } else {
+
     }
-    if(state[SDL_SCANCODE_E]){
-        marine->checkForPickUp();
-    }
-    if(state[SDL_SCANCODE_I]) {
-        marine->inventory.useItem();
-    }
-    marine->setDY(y);
-    marine->setDX(x);
+
 }
 
 void Player::handleTempBarricade(SDL_Renderer *renderer) {

--- a/src/player/Player.h
+++ b/src/player/Player.h
@@ -26,6 +26,10 @@ public:
     void handleTempBarricade(SDL_Renderer *renderer);
     void handleTempTurret(SDL_Renderer *renderer);
 
+    //Added by Matt Goerwell 03/14/2017
+    Ghost& getGhost() {return ghost;}
+    void moveGhost(const float delta);
+
     Player();
     ~Player();
 
@@ -33,6 +37,7 @@ public:
     Marine *marine = NULL;
 
 private:
+    Ghost ghost;
     int tempBarricadeID;
     int tempTurretID;
 };

--- a/src/player/Player.h
+++ b/src/player/Player.h
@@ -3,6 +3,7 @@
 #include <string>
 #include "../sprites/LTexture.h"
 #include "../player/Marine.h"
+#include "../player/Ghost.h"
 #include "../turrets/Turret.h"
 #include "../inventory/Inventory.h"
 #include <SDL2/SDL.h>


### PR DESCRIPTION
This Commit contains:
-A spectator class (Ghost)
-The ability to kill yourself as a marine (K on the keyboard)
-Spectator movement and camera trailing

Note:
Collision Hit-boxes for the ghost currently follows the same as a marine in regards to ghost movement, although they do not impede zombie movement. This is a known issue that will be resolved after the Collision system rework.